### PR TITLE
fix(mal): set as completed only if it finished airing or publishing

### DIFF
--- a/lib/components/trackers/detailed_item.dart
+++ b/lib/components/trackers/detailed_item.dart
@@ -356,9 +356,9 @@ class _DetailedItemState extends State<DetailedItem> {
                                       fontWeight: FontWeight.bold,
                                     ),
                               ),
-                              if (item.status != null)
+                              if (item.userStatus != null)
                                 TextSpan(
-                                  text: '  (${item.status})',
+                                  text: '  (${item.userStatus})',
                                 ),
                             ],
                           ),

--- a/lib/core/trackers/anilist/handlers/media_list.dart
+++ b/lib/core/trackers/anilist/handlers/media_list.dart
@@ -173,7 +173,7 @@ mutation (
         type: media.type,
         thumbnail: media.coverImageExtraLarge,
         banner: media.bannerImage,
-        status: status.pretty,
+        userStatus: status.pretty,
         progress: detailed_info.Progress(
           progress: progress,
           total: media.episodes ?? media.chapters,
@@ -191,6 +191,8 @@ mutation (
         characters: media.characters
             .map((final Character x) => x.toCharacter())
             .toList(),
+        // TODO: implement
+        finishedAiring: false,
       );
 
   Widget getDetailedPage(

--- a/lib/core/trackers/detailed_info.dart
+++ b/lib/core/trackers/detailed_info.dart
@@ -45,11 +45,12 @@ class DetailedInfo {
     required final this.type,
     required final this.thumbnail,
     required final this.banner,
-    required final this.status,
+    required final this.userStatus,
     required final this.progress,
     required final this.score,
     required final this.repeated,
     required final this.characters,
+    required final this.finishedAiring,
   });
 
   final String title;
@@ -57,9 +58,10 @@ class DetailedInfo {
   final extensions.ExtensionType type;
   final String thumbnail;
   final String? banner;
-  final String? status;
+  final String? userStatus;
   final Progress progress;
   final int? score;
   final int? repeated;
   final List<Character> characters;
+  final bool finishedAiring;
 }

--- a/lib/core/trackers/myanimelist/handlers/anime.dart
+++ b/lib/core/trackers/myanimelist/handlers/anime.dart
@@ -71,7 +71,7 @@ Future<AnimeListEntity> scrapeFromNodeId(final int nodeId) async {
     title: document.querySelector('.title-name')!.text.trim(),
     mainPictureMedium: thumbnail,
     mainPictureLarge: thumbnail,
-    status: null,
+    userStatus: null,
     details: AnimeListAdditionalDetail(
       synopsis: document.querySelector('[itemprop="description"]')!.text,
       characters: document
@@ -88,6 +88,7 @@ Future<AnimeListEntity> scrapeFromNodeId(final int nodeId) async {
         );
       }).toList(),
       totalEpisodes: int.tryParse(metas['Episodes'] ?? ''),
+      finishedAiring: metas['Status'].toString().contains('Finished'),
     ),
   );
 }

--- a/lib/core/trackers/myanimelist/handlers/animelist.dart
+++ b/lib/core/trackers/myanimelist/handlers/animelist.dart
@@ -60,11 +60,13 @@ class AnimeListAdditionalDetail {
     required final this.synopsis,
     required final this.characters,
     required final this.totalEpisodes,
+    required final this.finishedAiring,
   });
 
   final String synopsis;
   final List<Character> characters;
   final int? totalEpisodes;
+  final bool finishedAiring;
 }
 
 class AnimeListEntity {
@@ -73,7 +75,7 @@ class AnimeListEntity {
     required final this.title,
     required final this.mainPictureMedium,
     required final this.mainPictureLarge,
-    required final this.status,
+    required final this.userStatus,
     required final this.details,
   });
 
@@ -83,7 +85,7 @@ class AnimeListEntity {
         title: json['node']['title'] as String,
         mainPictureMedium: json['node']['main_picture']['medium'] as String,
         mainPictureLarge: json['node']['main_picture']['large'] as String,
-        status: AnimeListEntityProgress.fromJson(
+        userStatus: AnimeListEntityProgress.fromJson(
           json['list_status'] as Map<dynamic, dynamic>,
         ),
         details: null,
@@ -95,7 +97,7 @@ class AnimeListEntity {
         title: json['title'] as String,
         mainPictureMedium: json['main_picture']['medium'] as String,
         mainPictureLarge: json['main_picture']['large'] as String,
-        status: json.containsKey('my_list_status')
+        userStatus: json.containsKey('my_list_status')
             ? AnimeListEntityProgress.fromJson(
                 json['my_list_status'] as Map<dynamic, dynamic>,
               )
@@ -104,6 +106,7 @@ class AnimeListEntity {
           synopsis: json['synopsis'] as String,
           totalEpisodes: json['num_episodes'] as int,
           characters: <Character>[],
+          finishedAiring: false,
         ),
       );
 
@@ -111,7 +114,7 @@ class AnimeListEntity {
   final String title;
   final String mainPictureMedium;
   final String mainPictureLarge;
-  AnimeListEntityProgress? status;
+  AnimeListEntityProgress? userStatus;
   AnimeListAdditionalDetail? details;
 
   Future<void> update({
@@ -129,7 +132,7 @@ class AnimeListEntity {
       if (watched != null) 'num_watched_episodes': watched.toString(),
     });
 
-    this.status = AnimeListEntityProgress.fromJson(
+    this.userStatus = AnimeListEntityProgress.fromJson(
       json.decode(res) as Map<dynamic, dynamic>,
     );
   }
@@ -152,17 +155,18 @@ class AnimeListEntity {
         type: extensions.ExtensionType.anime,
         thumbnail: mainPictureLarge,
         banner: null,
-        status: status?.status.pretty,
+        userStatus: userStatus?.status.pretty,
         progress: Progress(
-          progress: status?.watched ?? 0,
+          progress: userStatus?.watched ?? 0,
           total: details?.totalEpisodes,
           startedAt: null,
           completedAt: null,
           volumes: null,
         ),
-        score: status?.score,
+        score: userStatus?.score,
         repeated: null,
         characters: details?.characters ?? <Character>[],
+        finishedAiring: details?.finishedAiring ?? false,
       );
 
   Widget getDetailedPage(

--- a/lib/core/trackers/myanimelist/handlers/mangalist.dart
+++ b/lib/core/trackers/myanimelist/handlers/mangalist.dart
@@ -67,12 +67,14 @@ class MangaListAdditionalDetail {
     required final this.characters,
     required final this.totalChapters,
     required final this.totalVolumes,
+    required final this.finishedPublishing,
   });
 
   final String synopsis;
   final List<Character> characters;
   final int? totalChapters;
   final int? totalVolumes;
+  final bool finishedPublishing;
 }
 
 class MangaListEntity {
@@ -113,6 +115,7 @@ class MangaListEntity {
           totalChapters: json['num_chapters'] as int,
           totalVolumes: json['num_volumes'] as int,
           characters: <Character>[],
+          finishedPublishing: false,
         ),
       );
 
@@ -192,6 +195,7 @@ class MangaListEntity {
       }).toList(),
       totalChapters: int.tryParse(metas['Chapters'] ?? ''),
       totalVolumes: int.tryParse(metas['Volumes'] ?? ''),
+      finishedPublishing: metas['Status'].toString().contains('Finished'),
     );
 
     _cacheDetails[nodeId] = details!;
@@ -203,7 +207,7 @@ class MangaListEntity {
         type: extensions.ExtensionType.manga,
         thumbnail: mainPictureLarge,
         banner: null,
-        status: status?.status.pretty,
+        userStatus: status?.status.pretty,
         progress: Progress(
           progress: status?.read ?? 0,
           total: details?.totalChapters,
@@ -217,6 +221,7 @@ class MangaListEntity {
         score: status?.score,
         repeated: null,
         characters: details?.characters ?? <Character>[],
+        finishedAiring: details?.finishedPublishing ?? false,
       );
 
   Widget getDetailedPage(

--- a/lib/core/trackers/myanimelist/providers/anime.dart
+++ b/lib/core/trackers/myanimelist/providers/anime.dart
@@ -105,20 +105,21 @@ final TrackerProvider<AnimeProgress> anime = TrackerProvider<AnimeProgress>(
     final myanimelist.AnimeListEntity info =
         media.info as myanimelist.AnimeListEntity;
     final myanimelist.AnimeListStatus status =
-        progress.episodes >= (info.status?.watched ?? -1)
+        progress.episodes >= (info.userStatus?.watched ?? -1) &&
+                info.details?.finishedAiring == true
             ? myanimelist.AnimeListStatus.completed
             : myanimelist.AnimeListStatus.watching;
 
     final int episodes = progress.episodes;
 
     final bool repeating =
-        progress.episodes == 1 && (info.status?.watched ?? -1) > 1;
+        progress.episodes == 1 && (info.userStatus?.watched ?? -1) > 1;
 
     int changes = 0;
     final List<List<dynamic>> changables = <List<dynamic>>[
-      <dynamic>[info.status?.status, status],
-      <dynamic>[info.status?.watched, episodes],
-      <dynamic>[info.status?.rewatching, repeating],
+      <dynamic>[info.userStatus?.status, status],
+      <dynamic>[info.userStatus?.watched, episodes],
+      <dynamic>[info.userStatus?.rewatching, repeating],
     ];
 
     for (final List<dynamic> item in changables) {

--- a/lib/core/trackers/myanimelist/providers/manga.dart
+++ b/lib/core/trackers/myanimelist/providers/manga.dart
@@ -105,7 +105,8 @@ final TrackerProvider<MangaProgress> manga = TrackerProvider<MangaProgress>(
     final myanimelist.MangaListEntity info =
         media.info as myanimelist.MangaListEntity;
     final myanimelist.MangaListStatus status =
-        progress.chapters >= (info.status?.read ?? -1)
+        progress.chapters >= (info.status?.read ?? -1) &&
+                info.details?.finishedPublishing == true
             ? myanimelist.MangaListStatus.completed
             : myanimelist.MangaListStatus.reading;
 

--- a/lib/pages/store_page/trackers_page/myanimelist_page/animelist/animelist_page.dart
+++ b/lib/pages/store_page/trackers_page/myanimelist_page/animelist/animelist_page.dart
@@ -151,7 +151,7 @@ class Page extends StatelessWidget {
                                 children: <InlineSpan>[
                                   TextSpan(
                                     text:
-                                        '${Translator.t.progress()}: ${x.status?.watched ?? 0}',
+                                        '${Translator.t.progress()}: ${x.userStatus?.watched ?? 0}',
                                   ),
                                   TextSpan(
                                     text:

--- a/lib/pages/store_page/trackers_page/myanimelist_page/animelist/edit_modal.dart
+++ b/lib/pages/store_page/trackers_page/myanimelist_page/animelist/edit_modal.dart
@@ -24,11 +24,11 @@ class EditModal extends StatefulWidget {
 }
 
 class _EditModalState extends State<EditModal> {
-  late myanimelist.AnimeListStatus status =
-      widget.media.status?.status ?? myanimelist.AnimeListStatus.planToWatch;
-  late int progress = widget.media.status?.watched ?? 0;
-  late int? score = widget.media.status?.score;
-  late bool repeating = widget.media.status?.rewatching ?? false;
+  late myanimelist.AnimeListStatus status = widget.media.userStatus?.status ??
+      myanimelist.AnimeListStatus.planToWatch;
+  late int progress = widget.media.userStatus?.watched ?? 0;
+  late int? score = widget.media.userStatus?.score;
+  late bool repeating = widget.media.userStatus?.rewatching ?? false;
 
   late TextEditingController progressController = TextEditingController(
     text: progress.toString(),


### PR DESCRIPTION
- Only set trackers as Completed if anime/manga is not still airing/publishing
- Rename `status` to `userStatus` to avoid confusion