### PR TITLE
Add Publisher to ARP Entry

### DIFF
--- a/cli/commands/windows/build/installer/installer.iss
+++ b/cli/commands/windows/build/installer/installer.iss
@@ -9,7 +9,7 @@
 #define MyAppSourceDir "{%- rootDir %}"
 #define MyAppOutputFileName "{%- setupName %}"
 #define MyAppOutputDir "{%- outputDir %}"
-#define MyAppPublisher "Yukino Development Team"
+#define MyAppPublisher "yukino-app.github.io"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.

--- a/cli/commands/windows/build/installer/installer.iss
+++ b/cli/commands/windows/build/installer/installer.iss
@@ -9,6 +9,7 @@
 #define MyAppSourceDir "{%- rootDir %}"
 #define MyAppOutputFileName "{%- setupName %}"
 #define MyAppOutputDir "{%- outputDir %}"
+#define MyAppPublisher "Yukino Development Team"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -17,6 +18,7 @@ AppId={{888060E5-9312-450D-91E1-C15DD1376FC0}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}


### PR DESCRIPTION
It is best practice to have a publisher specified in the Add/Remove Programs entry. This change adds a value to this field